### PR TITLE
Fix the remaining TODO

### DIFF
--- a/lib/morph-range.js
+++ b/lib/morph-range.js
@@ -98,16 +98,40 @@ Morph.prototype.setNode = function Morph$setNode(newNode) {
     var parentNode = previousFirstNode.parentNode;
     insertBefore(parentNode, firstNode, lastNode, previousFirstNode);
     clear(parentNode, previousFirstNode, this.lastNode);
+
+    if (previousFirstNode.previousSibling === null && this.parentMorph) {
+      updateFirstNode(this.parentMorph, firstNode);
+    }
   }
 
-  // TODO recursively set parentMorph.firstNode if we are its firstChildMorph
-  this.firstNode = firstNode;
+  var previousLastNode = this.lastNode;
+  if (previousLastNode !== null) {
+    if (previousLastNode.nextSibling === null && this.parentMorph) {
+      updateLastNode(this.parentMorph, lastNode);
+    }
+  }
 
-  // TODO recursively set parentMorph.lastNode if we are its lastChildMorph
+  this.firstNode = firstNode;
   this.lastNode  = lastNode;
 
   return newNode;
 };
+
+function updateFirstNode(parent, newChild) {
+  parent.firstNode = newChild;
+
+  if (parent.previousMorph === null && parent.parentMorph) {
+    updateFirstNode(parent.parentMorph, newChild);
+  }
+}
+
+function updateLastNode(parent, newChild) {
+  parent.lastNode = newChild;
+
+  if (parent.previousMorph === null && parent.parentMorph) {
+    updateLastNode(parent.parentMorph, newChild);
+  }
+}
 
 // return morph content to an undifferentiated state
 // drops knowledge that the node has content.
@@ -144,11 +168,17 @@ Morph.prototype.destroy = function Morph$destroy() {
     }
   }
 
+  if (previousMorph === null && parentMorph !== null) {
+    updateFirstNode(parentMorph, null);
+  }
+
+  if (nextMorph === null && parentMorph !== null) {
+    updateLastNode(parentMorph, null);
+  }
+
   clear(parentNode, firstNode, lastNode);
 
-  // TODO recursively set parentMorph.firstNode if we are its firstChildMorph
   this.firstNode = null;
-  // TODO recursively set parentMorph.lastNode if we are its lastChildMorph
   this.lastNode = null;
 };
 
@@ -158,13 +188,14 @@ Morph.prototype.setHTML = function(text) {
 };
 
 Morph.prototype.appendMorph = function(morph) {
-  this.insertMorphBefore(morph, null);
+  this.insertBeforeMorph(morph, null);
 };
 
 Morph.prototype.insertBeforeMorph = function(morph, _referenceMorph) {
   var referenceMorph = _referenceMorph ? _referenceMorph : this.lastChildMorph;
   var refNode = referenceMorph ? referenceMorph.firstNode : this.firstNode;
   var parentNode = refNode.parentNode;
+  morph.parentMorph = this;
   insertBefore(parentNode, morph.firstNode, morph.lastNode, refNode);
   if (!referenceMorph) {
     clear(parentNode, this.firstNode, this.lastNode);

--- a/test/morph-test.js
+++ b/test/morph-test.js
@@ -47,3 +47,63 @@ QUnit.test('can setContent of a morph', function (assert) {
   assert.equalHTML(el, '<div>\n<p>before  after</p>\n</div>', 'setting to empty');
 
 });
+
+QUnit.test("When a single-element morph is replaced with a new node, the firstNode and lastNode of parents are updated recursively", function(assert) {
+  var dom = domHelper();
+
+  var parentMorph = new Morph(dom);
+  parentMorph.clear();
+
+  var childMorph = new Morph(dom);
+  childMorph.clear();
+
+  var grandchildMorph = new Morph(dom);
+  grandchildMorph.clear();
+
+  var morphFrag = document.createDocumentFragment();
+  morphFrag.appendChild(parentMorph.firstNode);
+
+  parentMorph.appendMorph(childMorph);
+  childMorph.appendMorph(grandchildMorph);
+
+  var frag = document.createDocumentFragment();
+  var text = document.createTextNode('hello');
+  frag.appendChild(text);
+  grandchildMorph.setNode(frag);
+
+  assert.strictEqual(parentMorph.firstNode, childMorph.firstNode, '1');
+  assert.strictEqual(parentMorph.lastNode, childMorph.lastNode, '2');
+  assert.strictEqual(childMorph.firstNode, grandchildMorph.firstNode, '3');
+  assert.strictEqual(childMorph.lastNode, grandchildMorph.lastNode, '4');
+
+  assert.strictEqual(parentMorph.firstNode, text, '5');
+  assert.strictEqual(parentMorph.lastNode, text, '6');
+  assert.strictEqual(childMorph.firstNode, text, '7');
+  assert.strictEqual(childMorph.firstNode, text, '8');
+  assert.strictEqual(grandchildMorph.lastNode, text, '9');
+  assert.strictEqual(grandchildMorph.lastNode, text, '10');
+});
+
+QUnit.test("when destroying a morph, set the parent's first and last nodes to null if needed", function(assert) {
+  var dom = domHelper();
+
+  var parentMorph = new Morph(dom);
+  parentMorph.clear();
+
+  var childMorph = new Morph(dom);
+  childMorph.clear();
+
+  var morphFrag = document.createDocumentFragment();
+  morphFrag.appendChild(parentMorph.firstNode);
+
+  parentMorph.appendMorph(childMorph);
+
+  var frag = document.createDocumentFragment();
+  frag.appendChild(document.createTextNode('hello'));
+  childMorph.setNode(frag);
+
+  childMorph.destroy();
+
+  assert.equal(parentMorph.firstNode, null);
+  assert.equal(parentMorph.lastNode, null);
+});


### PR DESCRIPTION
When the first node or last node in a morph is replaced, recursively
update ancestor morphs whose `firstNode` was just removed.