### PR TITLE
Work around a Chrome whitespace+option bug

### DIFF
--- a/lib/morph-range/utils.js
+++ b/lib/morph-range/utils.js
@@ -18,7 +18,24 @@ export function insertBefore(parentNode, firstNode, lastNode, _refNode) {
   var node = lastNode;
   var refNode = _refNode;
   var prevNode;
+
+  // Chrome bug https://code.google.com/p/chromium/issues/detail?id=475337
+  var shouldFix = parentNode.tagName === 'SELECT' && parentNode.selectedIndex === -1;
+  var firstOption;
+
   do {
+
+    if (shouldFix && node.tagName === 'OPTION') {
+      // Track the first option added to the select
+      if (!firstOption) {
+        firstOption = node;
+      }
+      // Don't need to fix if an option is selected
+      if (node.selected) {
+        shouldFix = false;
+      }
+    }
+
     prevNode = node.previousSibling;
     parentNode.insertBefore(node, refNode);
     if (node === firstNode) {
@@ -26,5 +43,11 @@ export function insertBefore(parentNode, firstNode, lastNode, _refNode) {
     }
     refNode = node;
     node = prevNode;
+
   } while (node);
+
+  // Mark the first item added to the select selected
+  if (shouldFix && firstOption) {
+    firstOption.selected = true;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,12 @@
     "qunitjs": "^1.16.0",
     "simple-dom": "^0.2.0",
     "testem": "^0.6.24"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krisselden/morph-range.git"
+  },
+  "bugs": {
+    "url": "https://github.com/krisselden/morph-range/issues"
   }
 }

--- a/test/morph-test.js
+++ b/test/morph-test.js
@@ -1,7 +1,7 @@
 import QUnit from 'qunitjs';
 import Morph from 'morph-range';
 
-import { document, fragment, element, comment, domHelper } from 'support';
+import { document, fragment, element, comment, text, domHelper } from 'support';
 
 QUnit.module('Morph tests');
 
@@ -64,4 +64,67 @@ QUnit.test("When destroying a morph, do not explode if a parentNode does not exi
   var morph = new Morph(dom);
   morph.destroy();
   assert.ok(true, "The test did not crash");
+});
+
+// Chrome bug https://code.google.com/p/chromium/issues/detail?id=475337
+QUnit.test('can setContent options on a morph with whitespace', function (assert) {
+  var morph = new Morph(domHelper());
+  var select = element('select');
+  var placeholder = comment();
+  select.appendChild(placeholder);
+  morph.setNode(placeholder);
+
+  var frag = fragment(
+    element('option'),
+    text(''),
+    element('option')
+  );
+
+  morph.setContent(frag);
+
+  assert.equal(select.selectedIndex, 1, 'selectedIndex is the first item inserted');
+});
+
+QUnit.test('can setContent selected option on a morph with whitespace', function (assert) {
+  var morph = new Morph(domHelper());
+  var select = element('select');
+  var placeholder = comment();
+  select.appendChild(placeholder);
+  morph.setNode(placeholder);
+
+  var selectedOption = element('option');
+  selectedOption.selected = true;
+
+  var frag = fragment(
+    selectedOption,
+    text(''),
+    element('option')
+  );
+
+  morph.setContent(frag);
+
+  assert.equal(select.selectedIndex, 0, 'selectedIndex is the first item');
+});
+
+QUnit.test('can setContent option with a selectedIndex already set', function (assert) {
+  var morph = new Morph(domHelper());
+  var select = element('select');
+  var placeholder = comment();
+  select.appendChild(placeholder);
+
+  var selectedOption = element('option');
+  selectedOption.selected = true;
+  select.appendChild(selectedOption);
+
+  morph.setNode(placeholder);
+
+  var frag = fragment(
+    element('option'),
+    text(''),
+    element('option')
+  );
+
+  morph.setContent(frag);
+
+  assert.equal(select.selectedIndex, 2, 'selectedIndex is the first item');
 });


### PR DESCRIPTION
Chrome incorrectly changes the selected option of a `<select>` if you `insertBefore` an `<option>` after a text node. See: https://code.google.com/p/chromium/issues/detail?id=475337

Please review and merge if it seems good. Will need to be cherry-picked on to `v0.1.2` and released as `v0.1.3` for Ember 1.11 to get a point release.