### PR TITLE
Use domHelper.setMorphHTML rather than calling morph.setHTML directly

### DIFF
--- a/lib/morph-range.js
+++ b/lib/morph-range.js
@@ -56,10 +56,10 @@ Morph.prototype.setContent = function Morph$setContent(content) {
       }
       /* Handlebars.SafeString */
       if (typeof content.string === 'string') {
-        return this.setHTML(content.string);
+        return this.domHelper.setMorphHTML(this, content.string);
       }
       if (this.parseTextAsHTML) {
-        return this.setHTML(content.toString());
+        return this.domHelper.setMorphHTML(this, content.toString());
       }
       /* falls through */
     case 'boolean':

--- a/test/morph-test.js
+++ b/test/morph-test.js
@@ -67,6 +67,23 @@ QUnit.test('can setContent of a morph', function (assert) {
   assert.equalHTML(el, '<div>\n<p>before  after</p>\n</div>', 'setting to empty');
 });
 
+QUnit.test('calling setContent with a SafeString uses domHelper for parsing', function(assert) {
+  var dom = domHelper();
+  var setMorphHTMLCalledWith = undefined;
+
+  dom.setMorphHTML = function(morph, html) {
+    setMorphHTMLCalledWith = html;
+  };
+
+  var morph = new Morph(dom);
+
+  // SafeString
+  var html = '<span>Hello</span>';
+  morph.setContent({ string: html });
+
+  assert.equal(setMorphHTMLCalledWith, html);
+});
+
 QUnit.test("When destroying a morph, do not explode if a parentMorph does not exist", function(assert) {
   var dom = domHelper();
   var morph = new Morph(dom);


### PR DESCRIPTION
This fixes an issue where helpers returning SafeString in Node wouldn't
render, since morph.setHTML engages browser-specific parsing logic in
HTMLBars.