### PR TITLE
Remove usage of `DOMHelper#setMorphHTML`

### DIFF
--- a/lib/morph-range.js
+++ b/lib/morph-range.js
@@ -47,7 +47,7 @@ Morph.prototype.setContent = function Morph$setContent(content) {
   switch (type) {
     case 'string':
       if (this.parseTextAsHTML) {
-        return this.domHelper.setMorphHTML(this, content);
+        return this.setHTML(content);
       }
       return this.setText(content);
     case 'object':


### PR DESCRIPTION
This is an unnecessary layer of indirection as the method on DOM
helper does exactly what `Morph#setHTML` is already doing.