### PR TITLE
support callable HTMLObjectElement

### DIFF
--- a/lib/morph-range.js
+++ b/lib/morph-range.js
@@ -1,5 +1,9 @@
 import { clear, insertBefore } from './morph-range/utils';
 
+function isDomNode(content) {
+  return typeof content.nodeType === 'number';
+}
+
 // constructor just initializes the fields
 // use one of the static initializers to create a valid morph.
 function Morph(domHelper, contextualElement) {
@@ -51,7 +55,7 @@ Morph.prototype.setContent = function Morph$setContent(content) {
       }
       return this.setText(content);
     case 'object':
-      if (typeof content.nodeType === 'number') {
+      if (isDomNode(content)) {
         return this.setNode(content);
       }
       /* Handlebars.SafeString */
@@ -66,6 +70,9 @@ Morph.prototype.setContent = function Morph$setContent(content) {
     case 'number':
       return this.setText(content.toString());
     case 'function':
+      if (isDomNode(content)) {
+        return this.setNode(content);
+      }
       raiseCannotBindToFunction(content);
     default:
       throw new TypeError('unsupported content');


### PR DESCRIPTION
Related Mozilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=268945

Some HTML nodes are callable so their `typeof` returns `function`.
